### PR TITLE
Sandro g time stamp error solved

### DIFF
--- a/Src/Common/Services/BybitService.cs
+++ b/Src/Common/Services/BybitService.cs
@@ -11,7 +11,7 @@ namespace bybit.net.api
     public abstract class BybitService
     {
         private static readonly string UserAgent = "bybit.net.api/" + VersionInfo.GetVersion;
-        private static string CurrentTimeStamp => BybitParametersUtils.GetCurrentTimeStamp();
+        private readonly string CurrentTimeStamp;
         private readonly string? apiKey;
         private readonly string? apiSecret;
         private readonly string? url;
@@ -19,7 +19,7 @@ namespace bybit.net.api
         private readonly bool debugMode;
         private readonly string recvWindow;
 
-        public BybitService(HttpClient httpClient, string? apiKey = null, string? apiSecret = null, string? url = BybitConstants.HTTP_MAINNET_URL, bool debugMode = false, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW)
+        public BybitService(HttpClient httpClient, string? apiKey = null, string? apiSecret = null, string? url = null, bool debugMode = false, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW)
         {
             this.httpClient = httpClient;
             this.apiKey = apiKey;
@@ -27,13 +27,15 @@ namespace bybit.net.api
             this.url = url;
             this.debugMode = debugMode;
             this.recvWindow = recvWindow;
+            CurrentTimeStamp = BybitParametersUtils.GetCurrentTimeStamp();
         }
 
-        public BybitService(HttpClient httpClient, string? url = BybitConstants.HTTP_MAINNET_URL, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW)
+        public BybitService(HttpClient httpClient, string? url = null , string recvWindow = BybitConstants.DEFAULT_REC_WINDOW)
         {
             this.httpClient = httpClient;
             this.url = url;
             this.recvWindow = recvWindow;
+            CurrentTimeStamp = BybitParametersUtils.GetCurrentTimeStamp();
         }
 
         #region public exposed methods


### PR DESCRIPTION
Solving the Issue:

I am encountering an error when attempting to retrieve account information for the second time. Initially, when I instantiate the AccountServices class, it successfully returns the required information.

public class AccountService
{
BybitAccountService accountService = new(apiKey: KeysForTesting.Key, apiSecret: KeysForTesting.Secret, url: BybitConstants.HTTP_TESTNET_URL, debugMode: true);

public async Task<AccountItemDTO> GetAccountBalance(AccountType accountType, string? coin)
{
    var balance = await accountService.GetAccountBalance(accountType, coin);

    if (balance == null)
        return new AccountItemDTO();

    var accountList = JsonConvert.DeserializeObject<AccountListDTO>(JObject.Parse(balance)["result"].ToString());
    var accountItem = accountList?.List?.FirstOrDefault();

    return accountItem;
}
}
The problem arises when attempting to get information for the second time. The constant CurrentTimeStamp is not being updated with the current timestamp during subsequent runs, resulting in the following error:

{
"retCode": 10002,
"retMsg": "invalid request, please check your server timestamp or recv_window param. req_timestamp[1707082502162],server_timestamp[1707082494985],recv_window[5000]",
"result": {},
"retExtInfo": {},
"time": 1707082494985
}
Upon investigation, it was discovered that CurrentTimeStamp is only loaded during the application's startup and is not updated when a new instance of the class is created. Consequently, the constant retains the timestamp from the initial run during subsequent attempts, leading to the encountered error.

To resolve this issue, it is recommended to ensure that CurrentTimeStamp is updated either upon creating a new instance of the AccountService class or before making each API call. This adjustment will guarantee that the timestamp is always current for every API request.

Solving the Issue and Unit Test Errors:

I am pleased to report that I have successfully addressed the four unit test errors that were occurring due to the absence of orders.

V1.0.9 where not compiled because UT errors